### PR TITLE
Fixed logging format for unknown operations

### DIFF
--- a/renogybt/BTOneClient.py
+++ b/renogybt/BTOneClient.py
@@ -92,7 +92,7 @@ class BTOneClient:
             if self.on_data_callback is not None:
                 self.on_data_callback(self, self.data)
         else:
-            logging.warn("on_data_received: unknown operation={}.format(operation)")
+            logging.warn("on_data_received: unknown operation={}".format(operation))
 
     def __on_error(self, connectFailed = False, error = None):
         logging.error(f"Exception occured: {error}")


### PR DESCRIPTION
This minor fix causes an unknown operation to be logged correctly. 

The logged message for an unknown operation changes from 

```
on_data_received: unknown operation={}.format(operation)
```

to

```
on_data_received: unknown operation=42
```
