### PR TITLE
Received Data buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ mqtt:
       state_topic: "solar/stats"
       unit_of_measurement: "%"
       value_template: "{{ value_json.battery_percentage }}"
-
 # check output log for more fields
 ```
 
 **Custom logging**
 
-You can even upload it to your own server. If you write your custom API, the json data is posted as body of the HTTP call. The optional `auth_header` is sent as http header `Authorization: Bearer <auth-header>`
+Should you choose to upload to your own server, the json data is posted as body of the HTTP call. The optional `auth_header` is sent as http header `Authorization: Bearer <auth-header>`
 
 Example php code at the server:
 ```php

--- a/example.py
+++ b/example.py
@@ -11,6 +11,10 @@ data_logger: DataLogger = DataLogger(config)
 
 def on_data_received(client: BTOneClient, data):
     logging.debug("{} => {}".format(client.device.alias(), data))
+
+    if data["charging_status"] != "mqtt":
+        return
+
     if config['remote_logging'].getboolean('enabled'):
         data_logger.log_remote(json_data=data)
     if config['mqtt'].getboolean('enabled'):

--- a/example.py
+++ b/example.py
@@ -3,7 +3,7 @@ import configparser
 from renogybt import BTOneClient
 from renogybt import DataLogger
 
-logging.basicConfig(filename="renogy-bt2.log", filemode="a", level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 
 config = configparser.ConfigParser()
 config.read('config.ini')
@@ -11,9 +11,6 @@ data_logger: DataLogger = DataLogger(config)
 
 def on_data_received(client: BTOneClient, data):
     logging.debug("{} => {}".format(client.device.alias(), data))
-
-    if data["charging_status"] != "mqtt":
-        return
 
     if config['remote_logging'].getboolean('enabled'):
         data_logger.log_remote(json_data=data)

--- a/example.py
+++ b/example.py
@@ -3,7 +3,7 @@ import configparser
 from renogybt import BTOneClient
 from renogybt import DataLogger
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(filename="renogy-bt2.log", filemode="a", level=logging.DEBUG)
 
 config = configparser.ConfigParser()
 config.read('config.ini')

--- a/example.py
+++ b/example.py
@@ -11,13 +11,13 @@ data_logger: DataLogger = DataLogger(config)
 
 def on_data_received(client: BTOneClient, data):
     logging.debug("{} => {}".format(client.device.alias(), data))
-    if client.config['remote_logging'].getboolean('enabled'):
+    if config['remote_logging'].getboolean('enabled'):
         data_logger.log_remote(json_data=data)
-    if client.config['mqtt'].getboolean('enabled'):
+    if config['mqtt'].getboolean('enabled'):
         data_logger.log_mqtt(json_data=data)
-    if client.config['pvoutput'].getboolean('enabled'):
+    if config['pvoutput'].getboolean('enabled'):
         data_logger.log_pvoutput(json_data=data)
-    if not client.config['device'].getboolean('enable_polling'):
+    if not config['device'].getboolean('enable_polling'):
         client.disconnect()
 
 logging.info(f"Starting client: {config['device']['alias']} => {config['device']['mac_addr']}")

--- a/renogybt/BTOneClient.py
+++ b/renogybt/BTOneClient.py
@@ -79,6 +79,7 @@ class BTOneClient:
         self.poll_params() if self.config['device'].getboolean('enable_polling') == True else self.__read_params()
 
     def __on_data_received(self, value):
+        logging.info("on_data_received: {}".format(value))
         operation = bytes_to_int(value, 1, 1)
 
         if operation == 3:

--- a/renogybt/BTOneClient.py
+++ b/renogybt/BTOneClient.py
@@ -92,7 +92,7 @@ class BTOneClient:
             if self.on_data_callback is not None:
                 self.on_data_callback(self, self.data)
         else:
-            logging.warn("on_data_received: unknown operation={}.format(operation)")
+            logging.warn("on_data_received: unknown operation={}".format(operation))
 
     def __on_error(self, connectFailed = False, error = None):
         logging.error(f"Exception occured: {error}")

--- a/renogybt/BTOneClient.py
+++ b/renogybt/BTOneClient.py
@@ -93,7 +93,7 @@ class BTOneClient:
 
         expected_length = bytes_to_int(self.received_bytes, 2, 1) + 5
 
-        if expected_length == 0 or expected_length != len(self.received_bytes):
+        if expected_length == 0 or expected_length < len(self.received_bytes):
             return
 
         response_data = self.received_bytes[:expected_length]

--- a/renogybt/BTOneClient.py
+++ b/renogybt/BTOneClient.py
@@ -96,21 +96,21 @@ class BTOneClient:
         if expected_length == 0 or expected_length != len(self.received_bytes):
             return
 
-        packet_data = self.received_bytes[:expected_length]
+        response_data = self.received_bytes[:expected_length]
         self.received_bytes = self.received_bytes[expected_length+1:]
 
-        if not check_crc(packet_data):
+        if not check_crc(response_data):
             return
 
-        operation = bytes_to_int(packet_data, 1, 1)
+        operation = bytes_to_int(response_data, 1, 1)
 
         if operation == 3:
             logging.info("on_data_received: response for read operation")
-            self.data = parse_charge_controller_info(packet_data)
+            self.data = parse_charge_controller_info(response_data)
             if self.on_data_callback is not None:
                 self.on_data_callback(self, self.data)
         elif operation == 6:
-            self.data = parse_set_load_response(packet_data)
+            self.data = parse_set_load_response(response_data)
             logging.info("on_data_received: response for write operation")
             if self.on_data_callback is not None:
                 self.on_data_callback(self, self.data)

--- a/renogybt/BTOneClient.py
+++ b/renogybt/BTOneClient.py
@@ -51,7 +51,7 @@ class BTOneClient:
         except Exception as e:
             self.__on_error(True, e)
         except KeyboardInterrupt:
-            self.__on_error()
+            self.__on_error(False, "KeyboardInterrupt")
 
     def disconnect(self):
         self.device.disconnect()

--- a/renogybt/Utils.py
+++ b/renogybt/Utils.py
@@ -103,3 +103,11 @@ def parse_set_load_response(bs):
 def parse_temperature(raw_value):
     sign = raw_value >> 7
     return -(raw_value - 128) if sign == 1 else raw_value
+
+def check_crc(bs):
+    if len(bs) < 3:
+        return false
+
+    crc = libscrc.modbus(bs[:len(bs)-2])
+
+    return crc == bytes_to_int(bs, len(bs)-1, -2)


### PR DESCRIPTION
This pull request buffers received bytes until there's enough data to process a response. I used the [neilsheps/Renogy-BT2-Reader](https://github.com/neilsheps/Renogy-BT2-Reader) Arduino library as a reference especially the code in the `BT2Reader::notifyCallback` function in `BT2Reader.cpp`.

I 'veadded a `bytearray` property to `BTOneClient` class called  `received_bytes` to hold the buffered bytes. This is reset when `__read_params` is called ready to capture the response.

When `__on_data_received` is called the bytes in `value` are added to `received_bytes` if the received bytes start with `0xff` or the `received_bytes` buffer already has some bytes in it, otherwise the data is ignored. 

The expected length of the response, held at position 2 of the buffer plus 5 bytes to cover the header (3 bytes) and the checksum (2 bytes), is extracted and the length of the `received_bytes`buffer to see if there's enough data.

If there's enough data in the buffer the `expected_length` number of bytes are copied from buffer into a `response_data` variable, and removed from the `received_bytes` buffer.

The CRC checksum for the  is checked using a new function `check_crc` added to `Utils.py`, the response ignored if it check fails.

Finally the operation type is taken from the 2nd byte of the response and `response_data` is passed to either `parse_charge_controller_info` or `parse_set_load_response` as depending on whether is is a read or write operation response.
